### PR TITLE
Add XHTTP support for VMess, VLESS, and Trojan

### DIFF
--- a/Netch/Servers/Trojan/TrojanServer.cs
+++ b/Netch/Servers/Trojan/TrojanServer.cs
@@ -37,4 +37,29 @@ public class TrojanServer : Server
             _tlsSecureType = value;
         }
     }
+
+    #region XHTTP Settings
+    // Note: For Trojan, XHTTP implies using an HTTP-based transport layer before Trojan.
+    // The Netch UI and Trojan controller would need to handle this specific setup.
+    // These fields are added for model consistency and potential future use.
+
+    /// <summary>
+    /// Specifies the HTTP transport protocol if Trojan is to be wrapped in XHTTP.
+    /// Should be "http" if XHTTPMode is set.
+    /// </summary>
+    public string? TransferProtocol { get; set; } // Should be "http" for XHTTP
+
+    /// <summary>
+    /// XHTTP Mode when TransferProtocol is "http".
+    /// </summary>
+    public string? XHTTPMode { get; set; }
+
+    /// <summary>
+    /// Path for XHTTP (if applicable)
+    /// </summary>
+    public string? Path { get; set; }
+
+
+    public XHTTPSettingsModel? XHTTPSpecificSettings { get; set; } = new();
+    #endregion
 }

--- a/Netch/Servers/V2ray/V2rayConfig.cs
+++ b/Netch/Servers/V2ray/V2rayConfig.cs
@@ -197,4 +197,65 @@ public class Sockopt
     public bool tcpFastOpen { get; set; }
 }
 
+public class XMuxSettings
+{
+    public object maxConcurrency { get; set; } // int or string range
+    public object maxConnections { get; set; } // int or string range
+    public object cMaxReuseTimes { get; set; } // int or string range
+    public object hMaxRequestTimes { get; set; } // int or string range
+    public object hMaxReusableSecs { get; set; } // int or string range
+    public int? hKeepAlivePeriod { get; set; }
+}
+
+public class XHttpSettings
+{
+    public string path { get; set; }
+    public string[] host { get; set; }
+    public string method { get; set; } // XHTTP mode: "packet-up", "stream-up", "stream-one"
+
+    // 'extra' object fields
+    public string xPaddingBytes { get; set; }
+    public bool? noGRPCHeader { get; set; }
+    public bool? noSSEHeader { get; set; }
+
+    // packet-up specific
+    public object scMaxEachPostBytes { get; set; }
+    public object scMinPostsIntervalMs { get; set; }
+    public int? scMaxBufferedPosts { get; set; }
+
+    // stream-up specific
+    public object scStreamUpServerSecs { get; set; }
+
+    public XMuxSettings xmux { get; set; }
+    // downloadSettings is complex, will not include in this iteration
+}
+
+// Modify StreamSettings to include XHttpSettings
+public class StreamSettings
+{
+    public string network { get; set; }
+
+    public string security { get; set; }
+
+    public TlsSettings tlsSettings { get; set; }
+
+    public TcpSettings tcpSettings { get; set; }
+
+    public KcpSettings kcpSettings { get; set; }
+
+    public WsSettings wsSettings { get; set; }
+
+    public HttpSettings httpSettings { get; set; }
+
+    public QuicSettings quicSettings { get; set; }
+
+    public TlsSettings xtlsSettings { get; set; } // Renamed from TlsSettings to avoid conflict, used for XTLS
+
+    public GrpcSettings grpcSettings { get; set; }
+
+    public Sockopt sockopt { get; set; }
+
+    public XHttpSettings xhttpSettings { get; set; } // Added for XHTTP
+}
+
 #endregion

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -209,35 +209,83 @@ public static class V2rayConfigUtils
                     {
                         address = await server.AutoResolveHostnameAsync(),
                         port = server.Port,
-                        method = "",
+                        method = "", // Trojan doesn't have 'method' in the same way as SS
                         password = trojan.Password,
-                        flow = trojan.TLSSecureType == "xtls" ? "xtls-rprx-direct" : ""
+                        flow = trojan.TLSSecureType == "xtls" && trojan.TransferProtocol != "http" ? "xtls-rprx-direct" : "" // flow only for non-http xtls
                     }
                 };
 
-                outbound.streamSettings = new StreamSettings
+                // Default stream settings for Trojan (direct TCP)
+                var streamSettings = new StreamSettings
                 {
-                    network = "tcp",
+                    network = "tcp", // Default, can be overridden by XHTTP settings
                     security = trojan.TLSSecureType
                 };
+
+                if (trojan.TransferProtocol == "http" && !string.IsNullOrEmpty(trojan.XHTTPMode) && trojan.XHTTPSpecificSettings != null)
+                {
+                    streamSettings.network = "http"; // Override network to http for XHTTP
+                    // Basic httpSettings (Xray might still need this for path/host if not in xhttpSettings fully)
+                    streamSettings.httpSettings = new HttpSettings
+                    {
+                        path = trojan.Path,
+                        host = trojan.Host.SplitOrDefault()
+                    };
+
+                    var xhttpSettings = new XHttpSettings
+                    {
+                        method = trojan.XHTTPMode.ToLowerInvariant() == "auto" ? null : trojan.XHTTPMode,
+                        path = trojan.Path,
+                        host = trojan.Host.SplitOrDefault(),
+                    };
+
+                    var specificSettings = trojan.XHTTPSpecificSettings;
+                    xhttpSettings.xPaddingBytes = specificSettings.PaddingBytes;
+                    if (specificSettings.NoGRPCHeader) xhttpSettings.noGRPCHeader = true;
+                    if (specificSettings.NoSSEHeader) xhttpSettings.noSSEHeader = true;
+                    xhttpSettings.scMaxEachPostBytes = specificSettings.SCMaxEachPostBytes;
+                    xhttpSettings.scMinPostsIntervalMs = specificSettings.SCMinPostsIntervalMs;
+                    xhttpSettings.scMaxBufferedPosts = specificSettings.SCMaxBufferedPosts;
+                    xhttpSettings.scStreamUpServerSecs = specificSettings.SCStreamUpServerSecs;
+
+                    if (specificSettings.Xmux != null)
+                    {
+                        xhttpSettings.xmux = new XMuxSettings
+                        {
+                            maxConcurrency = specificSettings.Xmux.MaxConcurrency,
+                            maxConnections = specificSettings.Xmux.MaxConnections,
+                            cMaxReuseTimes = specificSettings.Xmux.CMaxReuseTimes,
+                            hMaxRequestTimes = specificSettings.Xmux.HMaxRequestTimes,
+                            hMaxReusableSecs = specificSettings.Xmux.HMaxReusableSecs,
+                            hKeepAlivePeriod = specificSettings.Xmux.HKeepAlivePeriod
+                        };
+                    }
+                    streamSettings.xhttpSettings = xhttpSettings;
+                }
+
+                // Apply TLS/XTLS settings regardless of XHTTP, as XHTTP is a transport layer
                 if (trojan.TLSSecureType != "none")
                 {
                     var tlsSettings = new TlsSettings
                     {
                         allowInsecure = Global.Settings.V2RayConfig.AllowInsecure,
-                        serverName = trojan.Host ?? ""
+                        serverName = trojan.Host ?? "" // SNI is usually the Host for Trojan
                     };
 
                     switch (trojan.TLSSecureType)
                     {
                         case "tls":
-                            outbound.streamSettings.tlsSettings = tlsSettings;
+                            streamSettings.tlsSettings = tlsSettings;
                             break;
                         case "xtls":
-                            outbound.streamSettings.xtlsSettings = tlsSettings;
+                            streamSettings.xtlsSettings = tlsSettings;
+                            // XTLS flow is handled in `vnext` user settings for VLESS,
+                            // for Trojan, it's typically direct or via other means if not TCP.
+                            // If XHTTP is used, XTLS direct flow might not be applicable.
                             break;
                     }
                 }
+                outbound.streamSettings = streamSettings;
 
                 if (Global.Settings.V2RayConfig.TCPFastOpen)
                 {
@@ -411,6 +459,56 @@ public static class V2rayConfigUtils
                 };
 
                 break;
+
+            case "http": // Handling for XHTTP, note network is "http"
+                // Standard httpSettings for basic path/host if not using XHTTP enhancements
+                streamSettings.httpSettings = new HttpSettings
+                {
+                    host = server.Host.SplitOrDefault(),
+                    path = server.Path.ValueOrDefault()
+                };
+
+                // Populate xhttpSettings if XHTTPMode is specified
+                if (!string.IsNullOrEmpty(server.XHTTPMode) && server.XHTTPSpecificSettings != null)
+                {
+                    var xhttpSettings = new XHttpSettings
+                    {
+                        method = server.XHTTPMode.ToLowerInvariant() == "auto" ? null : server.XHTTPMode,
+                        path = server.Path.ValueOrDefault(), // Reuse server Path for XHTTP path
+                        host = server.Host.SplitOrDefault(), // Reuse server Host for XHTTP host
+                    };
+
+                    var specificSettings = server.XHTTPSpecificSettings;
+                    xhttpSettings.xPaddingBytes = specificSettings.PaddingBytes;
+
+                    if (specificSettings.NoGRPCHeader)
+                        xhttpSettings.noGRPCHeader = true;
+
+                    if (specificSettings.NoSSEHeader)
+                        xhttpSettings.noSSEHeader = true;
+
+                    xhttpSettings.scMaxEachPostBytes = specificSettings.SCMaxEachPostBytes;
+                    xhttpSettings.scMinPostsIntervalMs = specificSettings.SCMinPostsIntervalMs;
+                    xhttpSettings.scMaxBufferedPosts = specificSettings.SCMaxBufferedPosts;
+                    xhttpSettings.scStreamUpServerSecs = specificSettings.SCStreamUpServerSecs;
+
+
+                    if (specificSettings.Xmux != null)
+                    {
+                        xhttpSettings.xmux = new XMuxSettings
+                        {
+                            maxConcurrency = specificSettings.Xmux.MaxConcurrency,
+                            maxConnections = specificSettings.Xmux.MaxConnections,
+                            cMaxReuseTimes = specificSettings.Xmux.CMaxReuseTimes,
+                            hMaxRequestTimes = specificSettings.Xmux.HMaxRequestTimes,
+                            hMaxReusableSecs = specificSettings.Xmux.HMaxReusableSecs,
+                            hKeepAlivePeriod = specificSettings.Xmux.HKeepAlivePeriod
+                        };
+                    }
+                    streamSettings.xhttpSettings = xhttpSettings;
+                }
+                break;
+
             default:
                 throw new MessageException($"transfer protocol \"{server.TransferProtocol}\" not implemented yet");
         }

--- a/Netch/Servers/V2ray/V2rayController.cs
+++ b/Netch/Servers/V2ray/V2rayController.cs
@@ -8,17 +8,17 @@ namespace Netch.Servers;
 
 public class V2rayController : Guard, IServerController
 {
-    public V2rayController() : base("v2ray-sn.exe")
+    public V2rayController() : base("xray.exe") // Changed from v2ray-sn.exe to xray.exe
     {
         //if (!Global.Settings.V2RayConfig.XrayCone)
         //    Instance.StartInfo.Environment["XRAY_CONE_DISABLED"] = "true";
     }
 
-    protected override IEnumerable<string> StartedKeywords => new[] { "started" };
+    protected override IEnumerable<string> StartedKeywords => new[] { "Xray", "started" }; // Adjusted for typical Xray startup message
 
-    protected override IEnumerable<string> FailedKeywords => new[] { "config file not readable", "failed to" };
+    protected override IEnumerable<string> FailedKeywords => new[] { "config file not readable", "failed to" }; // These should be general enough
 
-    public override string Name => "V2Ray (SagerNet)";
+    public override string Name => "Xray"; // Updated name
 
     public ushort? Socks5LocalPort { get; set; }
 

--- a/Netch/Servers/VMess/VMessServer.cs
+++ b/Netch/Servers/VMess/VMessServer.cs
@@ -100,6 +100,54 @@ public class VMessServer : Server
     public bool? UseMux { get; set; }
 
     public string? ServerName { get; set; } = string.Empty;
+
+    #region XHTTP Settings
+    /// <summary>
+    /// XHTTP Mode when TransferProtocol is "http".
+    /// Modes: "packet-up", "stream-up", "stream-one", or "auto" (Netch client logic to pick one).
+    /// Empty or null means standard HTTP transport.
+    /// </summary>
+    public string? XHTTPMode { get; set; }
+
+    public XHTTPSettingsModel? XHTTPSpecificSettings { get; set; } = new(); // Initialize for easier handling
+    #endregion
+}
+
+public class XHTTPSettingsModel
+{
+    public string? PaddingBytes { get; set; } = "100-1000";
+
+    public bool NoGRPCHeader { get; set; } = false;
+
+    public bool NoSSEHeader { get; set; } = false;
+
+    // packet-up specific
+    public string? SCMaxEachPostBytes { get; set; } // Allow string for range "500000-1000000"
+
+    public string? SCMinPostsIntervalMs { get; set; } // Allow string for range "10-50"
+
+    public int? SCMaxBufferedPosts { get; set; } = 30;
+
+    // stream-up specific
+    public string? SCStreamUpServerSecs { get; set; } = "20-80";
+
+
+    public XHTTPMuxSettingsModel? Xmux { get; set; } = new(); // Initialize to allow easy UI binding
+}
+
+public class XHTTPMuxSettingsModel
+{
+    public string? MaxConcurrency { get; set; } = "16-32";
+
+    public string? MaxConnections { get; set; } = "0";
+
+    public string? CMaxReuseTimes { get; set; } = "0";
+
+    public string? HMaxRequestTimes { get; set; } = "600-900";
+
+    public string? HMaxReusableSecs { get; set; } = "1800-3000";
+
+    public int? HKeepAlivePeriod { get; set; } = 0;
 }
 
 public class VMessGlobal

--- a/Other/_Archive/v2ray-core/build.ps1
+++ b/Other/_Archive/v2ray-core/build.ps1
@@ -1,25 +1,44 @@
 Set-Location (Split-Path $MyInvocation.MyCommand.Path -Parent)
 
-git clone https://github.com/v2fly/v2ray-core -b 'v4.43.0' src
+# Remove existing src directory if it exists, to ensure a clean clone
+if (Test-Path src) {
+    Remove-Item -Recurse -Force src
+}
+
+git clone https://github.com/XTLS/Xray-core -b 'v25.6.8' src
 if ( -Not $? ) {
+    Write-Error "Failed to clone Xray-core repository."
     exit $lastExitCode
 }
 Set-Location src
 
 $Env:CGO_ENABLED='0'
-$Env:GOROOT_FINAL='/usr'
+$Env:GOROOT_FINAL='/usr' # This might not be necessary for Xray-core builds, but keeping for consistency for now
 
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
-go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray.exe' '.\main'
+
+Write-Host "Building xray.exe..."
+go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\xray.exe' '.\main'
 if ( -Not $? ) {
+    Write-Error "Failed to build xray.exe."
     exit $lastExitCode
 }
 
-go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -tags confonly -o '..\..\release\v2ctl.exe' '.\infra\control\main'
+# v2ctl.exe is no longer built from this path in Xray-core.
+# Write-Host "Building v2ctl.exe (now xrayctl.exe potentially, or removed)..."
+# go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -tags confonly -o '..\..\release\xrayctl.exe' '.\infra\control\main' # Path needs verification if utility is still built
+# if ( -Not $? ) {
+#     Write-Warning "Failed to build xrayctl.exe. This might be normal if the utility path changed or was removed."
+#     # Do not exit, as the main xray.exe is more critical.
+# }
+
+Write-Host "Building wxray.exe..."
+go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid= -H windowsgui' -o '..\..\release\wxray.exe' '.\main'
 if ( -Not $? ) {
+    Write-Error "Failed to build wxray.exe."
     exit $lastExitCode
 }
 
-go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid= -H windowsgui' -o '..\..\release\wv2ray.exe' '.\main'
-exit $lastExitCode
+Write-Host "Xray-core build script finished."
+exit 0 # Explicitly exit with 0 on success


### PR DESCRIPTION
- Add XHttpSettings and XMuxSettings to V2rayConfig.cs for Xray JSON structure.
- Update VMessServer.cs and TrojanServer.cs models to include XHTTP configuration options (XHTTPMode, XHTTPSpecificSettings with padding, headers, sc* params, XMux).
- VLESSServer.cs inherits XHTTP settings from VMessServer.
- Modify V2rayConfigUtils.cs to correctly populate streamSettings.xhttpSettings when 'http' transport is used with an XHTTP mode for VMess, VLESS, and Trojan.
- Update Other/_Archive/v2ray-core/build.ps1 to clone and build XTLS/Xray-core v25.6.8, outputting xray.exe and wxray.exe, and remove v2ctl build.
- Update Netch/Servers/V2ray/V2rayController.cs to use 'xray.exe' as the executable and update its display name to 'Xray'. Adjust startup detection keywords.